### PR TITLE
Construct BBCode with custom parsers

### DIFF
--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -12,10 +12,10 @@ final class BBCode
 
     const CASE_SENSITIVE = 0;
 
-    public function __construct()
+    public function __construct($htmlParsers = null, $bbCodeParsers = null)
     {
-        $this->htmlParser = new HTMLParser();
-        $this->bbCodeParser = new BBCodeParser();
+        $this->htmlParser = new HTMLParser($htmlParsers);
+        $this->bbCodeParser = new BBCodeParser($bbCodeParsers);
     }
 
     public function only($only = null)

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -12,6 +12,11 @@ class Parser
 
     protected $parsers = [];
 
+    public function __construct($parsers = null)
+    {
+        $this->parsers = $parsers === null ? $this->parsers : $parsers;
+    }
+    
     protected function searchAndReplace(string $pattern, string $replace, string $source): string
     {
         while (preg_match($pattern, $source)) {


### PR DESCRIPTION
Some may want to implement a set of bbcode tags which are completely different from the default ones. It would be pretty inconvenient for them to call `addParser` many times to set all of their tags and call `except` with an array of all the existing tags they don't want to disable them. This allows customizing a large amount of tags to be easier.